### PR TITLE
Fix source links

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,8 @@ defmodule XRPC.MixProject do
         "README.md": [title: "Overview"],
         LICENSE: [title: "License"]
       ],
-      main: "readme"
+      main: "readme",
+      source_url: @source_url
     ]
   end
 


### PR DESCRIPTION
Hello. I was checking out this library, and noticed the hex docs source links were broken.

This one-line change fixes it.